### PR TITLE
ENH/API: bit_array_get_bits

### DIFF
--- a/bit_array.c
+++ b/bit_array.c
@@ -664,6 +664,22 @@ char bit_array_get_bit(const BIT_ARRAY* bitarr, bit_index_t b)
   return bit_array_get(bitarr, b);
 }
 
+// Get the offsets of the set bits, returns the number of bits set
+// It is assumed that dst is at least of length end
+bit_index_t bit_array_get_bits(const BIT_ARRAY* bitarr, bit_index_t end, bit_index_t* dst)
+{
+    bit_index_t i;
+    bit_index_t bits_set = 0;
+
+    assert(end <= bitarr->num_of_bits);
+    for(i = 0; i < end; i++) {
+       if(bit_array_get(bitarr, i) == 1) {
+          dst[bits_set++] = i;
+       }
+    }
+    return bits_set;
+}
+
 // set a bit (to 1) at position b
 void bit_array_set_bit(BIT_ARRAY* bitarr, bit_index_t b)
 {

--- a/bit_array.h
+++ b/bit_array.h
@@ -96,6 +96,7 @@ void bit_array_ensure_size_critical(BIT_ARRAY* bitarr, bit_index_t num_of_bits);
 
 // Get the value of a bit (returns 0 or 1)
 char bit_array_get_bit(const BIT_ARRAY* bitarr, bit_index_t b);
+bit_index_t bit_array_get_bits(const BIT_ARRAY* bitarr, bit_index_t end, bit_index_t* dst);
 void bit_array_set_bit(BIT_ARRAY* bitarr, bit_index_t b);
 void bit_array_clear_bit(BIT_ARRAY* bitarr, bit_index_t b);
 void bit_array_toggle_bit(BIT_ARRAY* bitarr, bit_index_t b);


### PR DESCRIPTION
A method to get the index positions of the set bits within a `BIT_ARRAY`. This method arose as I needed to interrogate individual bits frequently. The function overhead of making calls to `bit_array_get_bit` was very large in my application, and this was an easy performance improvement.

There may be more efficient ways of doing this method, such as checking doing lookups based on the bit patterns for a given word or byte, but I'm not able to explore at this time.

Thank you @noporpoise for this library -- it has been very enjoyable to use. 