### PR TITLE
Fix memory leak in bit_array_test

### DIFF
--- a/dev/bit_array_test.c
+++ b/dev/bit_array_test.c
@@ -2548,6 +2548,10 @@ void test_bar_wrapper()
     ASSERT(barlen(&foo) >= rv);
   }
 
+  for (i = 1; i < 5; i++) {
+    barfree(&(bars[i]));
+  }
+
   barfree(&foo);
   ASSERT(barlen(&foo) == 0);
 


### PR DESCRIPTION
Running the tests through valgrind reports 1,024 bytes definitely 
lost. Tracking the origin of the allocation lead to line 2541 of 
bit_array_test.c. 

The cause of the leak is a loop copying a bitarray repeatedly, but
the copies are never freed. To resolve, an additional loop freeing
the bitarrays is added after the assertions are complete.