### PR TITLE
bit_array_add_uint64: fix adding value for each value in case of carry

### DIFF
--- a/bit_array.c
+++ b/bit_array.c
@@ -2358,6 +2358,7 @@ void bit_array_add_uint64(BIT_ARRAY* bitarr, uint64_t value)
     {
       carry = 1;
       bitarr->words[i] += value;
+      value = 1;
     }
     else
     {


### PR DESCRIPTION
Before this patch if carry happend we continued to add value for next words. But it seems that we should set value to 1

Example. How it worked:
```
words = {0...01b, 1....1b}
value = 2

first iteration (i = 0):
word[0] = 1...1b + 10b
leads to
word[0] = 0...01b
carry = 1

second iteration (i = 1).
word[1] = 0...01b + 10b
leads to
word[1] = 0...11b
carry = 0

but expected
word[1] = 0...10b
because we should add only 1 - carry
```
